### PR TITLE
Fix members with long display names overflowing `details`

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,15 @@ async function setFront() {
 
 		var front = (await axios(`/s/${system.id}/fronters`)).data;
 
+        members = front.members.map(m => m.display_name || m.name).join(", ");
+		if (members.length > 127) {
+			members = front.members.map(m => m.name).join(", ");
+			if (members.length > 127) {
+				members = members.slice(0, 120) + "...";
+			}
+		}
 		client.setActivity({
-			details: front.members.map(m => m.display_name || m.name).join(", ") || "(none)",
+			details: members || "(none)",
 			state: system.name || "---",
 			startTimestamp: new Date(front.timestamp),
 			//uncomment below if you want images & are using your own client


### PR DESCRIPTION
Names (and display names) can be up to 100 characters, while the `details` field has a maximum length of 128 characters; this means that having multiple people with long (display) names in front overflow the `details` field, causing RPC to error out and close.

- if all display names fit into 128 characters, just use that
- otherwise, fall back to normal names (these tend to be shorter because of pronouns and such)
- if it's *still* too long, cut it off at 120 characters and append ... to the end